### PR TITLE
fix: deduped slashes in edit page redirect

### DIFF
--- a/src/layouts/Entry.astro
+++ b/src/layouts/Entry.astro
@@ -29,8 +29,9 @@ const {
         {fullForm}
       </p>
       <p class="flex items-center gap-4 text-neutral-300 mt-2">
+        <!-- No slash after `/tones` subdirectory since tags always begin with a slash -->
         <a
-          href={`${GITHUB_URL}/tree/main/src/pages/tones/${tag}.mdx`}
+          href={`${GITHUB_URL}/tree/main/src/pages/tones${tag}.mdx`}
           class="hover:underline"
         >
           edit page

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,5 +1,7 @@
+import tailwindAnimate from "tailwindcss-animate";
+
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+export default {
   darkMode: ["class"],
   content: ["./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}"],
   prefix: "",
@@ -69,5 +71,5 @@ module.exports = {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [tailwindAnimate],
 };


### PR DESCRIPTION
This PR removes the duplicated slashes in the "edit page" URLs. This was due to the tone tags already having slashes, thus another one before the subdirectory was not necessary.

This PR also converts the contents of `tailwind.config.mjs` to actually contain ESM patterns instead of the present CommonJS patterns, contrary to the file name.